### PR TITLE
Fix parameter error in query builder

### DIFF
--- a/mario/query_builder.py
+++ b/mario/query_builder.py
@@ -1,5 +1,4 @@
 import logging
-import re
 from copy import copy
 from typing import List
 
@@ -9,6 +8,7 @@ from mario.data_extractor import Configuration
 from mario.dataset_specification import DatasetSpecification
 from mario.metadata import Metadata
 from mario.mapping import FieldMapping
+from mario.utils import to_snake_case
 
 logger = logging.getLogger(__name__)
 
@@ -173,8 +173,7 @@ class SubsetQueryBuilder(QueryBuilder):
             column = self.mapping.as_physical[constraint.item]
             placeholders = []
             for i in range(len(constraint.allowed_values)):
-                safe_column = re.sub(r'[^a-zA-Z0-9]', '_', column)
-                parameter_name = safe_column + str(i)
+                parameter_name = to_snake_case(column) + str(i)
                 # Postgres style.
                 # TODO Probably need some way of identifying which parameter style to apply.
                 parameter = Parameter('%('+parameter_name+')s')

--- a/mario/query_builder.py
+++ b/mario/query_builder.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from copy import copy
 from typing import List
 
@@ -172,7 +173,8 @@ class SubsetQueryBuilder(QueryBuilder):
             column = self.mapping.as_physical[constraint.item]
             placeholders = []
             for i in range(len(constraint.allowed_values)):
-                parameter_name = column.replace(" ", "_") + str(i)
+                safe_column = re.sub(r'[^a-zA-Z0-9]', '_', column)
+                parameter_name = safe_column + str(i)
                 # Postgres style.
                 # TODO Probably need some way of identifying which parameter style to apply.
                 parameter = Parameter('%('+parameter_name+')s')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='mario-pipeline-tools',
-    version='0.62',
+    version='0.63',
     packages=['mario'],
     url='https://github.com/JiscDACT/mario',
     license='all rights reserved',


### PR DESCRIPTION
- Use to_snake_case function to convert constraint parameter. Fix the error of this use case e.g. "Highest qualification on entry (detailed)"
- Release as mario=0.63