### PR TITLE
Cdspt 15587 align functionality of totals methods for all extractor subclasses

### DIFF
--- a/mario/athena.py
+++ b/mario/athena.py
@@ -1,5 +1,5 @@
 from pyathena import connect
-from mario.data_extractor import DataExtractor, Configuration
+from mario.data_extractor import DataExtractor, Configuration, GET_TOTAL_WITHOUT_MEASURE
 import logging
 import datetime
 import numbers
@@ -82,6 +82,8 @@ class AthenaDataExtractor(DataExtractor):
         :return: the total value of the query
         NOTE this is a direct copy from StreamingDataExtractor
         """
+        if measure is None:
+            logger.warning(GET_TOTAL_WITHOUT_MEASURE)
         measure = self.__get_measure__(measure)
         if measure is None:
             return self.get_row_count()

--- a/mario/athena.py
+++ b/mario/athena.py
@@ -56,18 +56,11 @@ class AthenaDataExtractor(DataExtractor):
             catalog_name=cfg.catalog
         )
 
-    def get_total(self, measure=None):
-        """
-        For totals when streaming data we need to run a totals SQL query separate
-        from the main query and use the results of this
-        :return: the total value of the query
-        NOTE this is a direct copy from StreamingDataExtractor
-        """
+    def __get_total__(self, measure):
         from pandas import read_sql
-        logger.info("Building totals query")
-        measure = self.__get_measure__(measure)
         if self.configuration.query_builder is not None:
             from mario.query_builder import QueryBuilder
+            logger.info("Building totals query")
             query_builder: QueryBuilder = self.configuration.query_builder(
                 configuration=self.configuration,
                 metadata=self.metadata,
@@ -78,6 +71,21 @@ class AthenaDataExtractor(DataExtractor):
 
         totals_df = read_sql(totals_query[0], self.get_connection(), params=totals_query[1])
         return totals_df.iat[0, 0]
+
+    def get_row_count(self):
+        return self.__get_total__(None)
+
+    def get_total(self, measure=None):
+        """
+        For totals when streaming data we need to run a totals SQL query separate
+        from the main query and use the results of this
+        :return: the total value of the query
+        NOTE this is a direct copy from StreamingDataExtractor
+        """
+        measure = self.__get_measure__(measure)
+        if measure is None:
+            return self.get_row_count()
+        return self.__get_total__(measure)
 
     def run_query(self) -> str:
         """

--- a/mario/data_extractor.py
+++ b/mario/data_extractor.py
@@ -131,11 +131,28 @@ class DataExtractor:
                 raise ValueError(f"Measure {measure} does not exist in dataset specification")
         return measure
 
-    def get_total(self, measure=None):
+    def get_row_count(self):
+        """
+        :return: the number of rows in the data
+        """
         df = self.get_data_frame()
+        return len(df)
+
+    def get_total(self, measure=None):
+        """
+        Returns the total from the dataset, using either the supplied measure, or
+        the default measure from the dataset specification if no measure is supplied.
+        If an invalid measure is supplied, a ValueError will be raised.
+        If no measure is supplied, and no measure exists in the dataset, the row_count()
+        is returned instead.
+        :param measure: the measure to use
+        :return: the sum of the data with the measure
+        """
         measure = self.__get_measure__(measure)
         if measure is None:
-            return len(df)
+            return self.get_row_count()
+
+        df = self.get_data_frame()
         self._total = df[measure].sum()
         return self._total
 
@@ -256,22 +273,30 @@ class HyperFile(DataExtractor):
             table=table
         )
 
-    def get_total(self, measure=None):
-        from mario.hyper_utils import get_row_count, get_default_table_and_schema, get_total
+    def get_row_count(self):
+        from mario.hyper_utils import get_row_count as __get_row_count__
+        from mario.hyper_utils import get_default_table_and_schema
         schema, table = get_default_table_and_schema(self.configuration.file_path)
+        return __get_row_count__ (
+            hyper_file_path=self.configuration.file_path,
+            schema=schema,
+            table=table
+        )
+
+    def get_total(self, measure=None):
+        measure = self.__get_measure__(measure)
         if measure is None:
-            return get_row_count(
-                hyper_file_path=self.configuration.file_path,
-                schema=schema,
-                table=table
-            )
-        else:
-            return get_total(
-                hyper_file_path=self.configuration.file_path,
-                schema=schema,
-                table=table,
-                measure=measure
-            )
+            return self.get_row_count()
+
+        from mario.hyper_utils import get_total as __get_total__
+        from mario.hyper_utils import get_default_table_and_schema
+        schema, table = get_default_table_and_schema(self.configuration.file_path)
+        return  __get_total__(
+            hyper_file_path=self.configuration.file_path,
+            schema=schema,
+            table=table,
+            measure=measure
+        )
 
     def save_data_as_hyper(self, file_path: str, **kwargs):
         from mario.hyper_utils import save_hyper_as_hyper, add_row_numbers_to_hyper, get_default_table_and_schema
@@ -360,26 +385,33 @@ class StreamingDataExtractor(DataExtractor):
             **kwargs
         )
 
+    def __get_total__(self, measure):
+        if self.configuration.query_builder is not None:
+            from mario.query_builder import QueryBuilder
+            logger.info("Building totals query")
+            query_builder: QueryBuilder = self.configuration.query_builder(
+                configuration=self.configuration,
+                metadata=self.metadata,
+                dataset_specification=self.dataset_specification)
+            totals_query = query_builder.create_totals_query(measure=measure)
+            totals_df = pd.read_sql(totals_query[0], self.get_connection(), params=totals_query[1])
+            return totals_df.iat[0, 0]
+        else:
+            raise NotImplementedError
+
+    def get_row_count(self):
+        return self.__get_total__(None)
+
     def get_total(self, measure=None):
         """
         For totals when streaming data we need to run a totals SQL query separate
         from the main query and use the results of this
         :return: the total value of the query
         """
-        logger.info("Building totals query")
         measure = self.__get_measure__(measure)
-        if self.configuration.query_builder is not None:
-            from mario.query_builder import QueryBuilder
-            query_builder: QueryBuilder = self.configuration.query_builder(
-                configuration=self.configuration,
-                metadata=self.metadata,
-                dataset_specification=self.dataset_specification)
-            totals_query = query_builder.create_totals_query(measure=measure)
-        else:
-            raise NotImplementedError
-
-        totals_df = pd.read_sql(totals_query[0], self.get_connection(), params=totals_query[1])
-        return totals_df.iat[0, 0]
+        if measure is None:
+            return self.get_row_count()
+        return self.__get_total__(measure)
 
     def stream_sql_to_hyper(self, file_path: str, **kwargs):
         """
@@ -607,6 +639,9 @@ class PartitioningExtractor(StreamingDataExtractor):
             self.__load_from_sql_using_partition__(partition_value=value)
 
     def get_data_frame(self, minimise=True, include_row_numbers=False) -> DataFrame:
+        raise NotImplementedError()
+
+    def get_row_count(self):
         raise NotImplementedError()
 
     def get_total(self, measure=None):

--- a/mario/data_extractor.py
+++ b/mario/data_extractor.py
@@ -143,6 +143,11 @@ class DataExtractor:
         df = self.get_data_frame()
         return len(df)
 
+    def __get_total__(self, measure):
+        df = self.get_data_frame()
+        self._total = df[measure].sum()
+        return self._total
+
     def get_total(self, measure=None):
         """
         Returns the total from the dataset, using either the supplied measure, or
@@ -158,10 +163,7 @@ class DataExtractor:
         measure = self.__get_measure__(measure)
         if measure is None:
             return self.get_row_count()
-
-        df = self.get_data_frame()
-        self._total = df[measure].sum()
-        return self._total
+        return self.__get_total__(measure)
 
     def validate_data(self, allow_nulls=True):
         from mario.validation import DataFrameValidator
@@ -290,13 +292,7 @@ class HyperFile(DataExtractor):
             table=table
         )
 
-    def get_total(self, measure=None):
-        if measure is None:
-            logger.warning(GET_TOTAL_WITHOUT_MEASURE)
-        measure = self.__get_measure__(measure)
-        if measure is None:
-            return self.get_row_count()
-
+    def __get_total__(self, measure):
         from mario.hyper_utils import get_total as __get_total__
         from mario.hyper_utils import get_default_table_and_schema
         schema, table = get_default_table_and_schema(self.configuration.file_path)
@@ -306,6 +302,14 @@ class HyperFile(DataExtractor):
             table=table,
             measure=measure
         )
+
+    def get_total(self, measure=None):
+        if measure is None:
+            logger.warning(GET_TOTAL_WITHOUT_MEASURE)
+        measure = self.__get_measure__(measure)
+        if measure is None:
+            return self.get_row_count()
+        return self.__get_total__(measure)
 
     def save_data_as_hyper(self, file_path: str, **kwargs):
         from mario.hyper_utils import save_hyper_as_hyper, add_row_numbers_to_hyper, get_default_table_and_schema

--- a/mario/data_extractor.py
+++ b/mario/data_extractor.py
@@ -12,6 +12,11 @@ from mario.mapping import FieldMapping
 logger = logging.getLogger(__name__)
 
 
+GET_TOTAL_WITHOUT_MEASURE = 'Deprecation warning: Calling get_total() without any measure specified, or with None, ' \
+                            'is going to be deprecated in future. Instead you should either call get_row_count(), ' \
+                            'or get_total(measure) where the measure exists in the dataset.'
+
+
 class Configuration:
     """
     Configuration for a data extractor. This can include:
@@ -148,6 +153,8 @@ class DataExtractor:
         :param measure: the measure to use
         :return: the sum of the data with the measure
         """
+        if measure is None:
+            logger.warning(GET_TOTAL_WITHOUT_MEASURE)
         measure = self.__get_measure__(measure)
         if measure is None:
             return self.get_row_count()
@@ -284,6 +291,8 @@ class HyperFile(DataExtractor):
         )
 
     def get_total(self, measure=None):
+        if measure is None:
+            logger.warning(GET_TOTAL_WITHOUT_MEASURE)
         measure = self.__get_measure__(measure)
         if measure is None:
             return self.get_row_count()
@@ -408,6 +417,8 @@ class StreamingDataExtractor(DataExtractor):
         from the main query and use the results of this
         :return: the total value of the query
         """
+        if measure is None:
+            logger.warning(GET_TOTAL_WITHOUT_MEASURE)
         measure = self.__get_measure__(measure)
         if measure is None:
             return self.get_row_count()

--- a/mario/query_builder.py
+++ b/mario/query_builder.py
@@ -101,23 +101,23 @@ class SubsetQueryBuilder(QueryBuilder):
                     return True
         return False
 
+    def __get_measure_label__(self, measure:str):
+        if measure in ['FPE', 'FTE'] and not self.contains_subject():
+            return 'Count'
+        return measure
+
     def create_totals_query(self, measure=None) -> [str, List[any]]:
         """
         Constructs a 'total only' query by combining the selections and constraints.
         :return: an array containing the query prepared statement, and the parameters
-        TODO make this more generic
         """
         measures = []
-        measure = self.mapping.as_physical[measure]
         if measure is None:
-            for measure in self.dataset_specification.measures:
-                # Decide column name based on whether 'subject' fields are present
-                if measure in ['FPE', 'FTE'] and not self.contains_subject():
-                    measures.append(fn.Sum(self.table[measure], 'Count'))
-                else:
-                    measures.append(fn.Sum(self.table[measure], measure))
+            measures.append(fn.Count('*', 'Count'))
         else:
-            measures.append(fn.Sum(self.table[measure], measure))
+            measure_label = self.__get_measure_label__(measure)
+            measure = self.mapping.as_physical[measure]
+            measures.append(fn.Sum(self.table[measure], measure_label))
 
         q = Query().from_(self.table).select(*measures)
 
@@ -141,15 +141,12 @@ class SubsetQueryBuilder(QueryBuilder):
         # remove measures from regular select
         measures = []
         for measure_field in self.dataset_specification.measures:
+            measure_label = self.__get_measure_label__(measure_field)
             measure = self.mapping.as_physical[measure_field]
             if measure in select_fields:
                 select_fields.remove(measure)
                 group_fields.remove(measure)
-                # Decide column name based on whether 'subject' fields are present
-                if measure in ['FPE', 'FTE'] and not self.contains_subject():
-                    measures.append(fn.Sum(self.table[measure], 'Count'))
-                else:
-                    measures.append(fn.Sum(self.table[measure], measure))
+                measures.append(fn.Sum(self.table[measure], measure_label))
         select_fields.extend(measures)
 
         q = Query(). \

--- a/test/test_athena_extractor.py
+++ b/test/test_athena_extractor.py
@@ -106,6 +106,26 @@ def test_athena_count():
     total = extractor.get_total(measure=dataset.measures[0])
     assert total == 28_733_910
 
+
+def test_athena_row_count():
+    if not AWS_PROFILE or not AWS_ATHENA_RESULTS_DIR or not AWS_REGION:
+        pytest.skip("Skipping Athena test as AWS not configured")
+
+    dataset, metadata, cfg = get_test_conf()
+    cfg.query_builder = SubsetQueryBuilder
+    cfg.schema = 'demo'
+    cfg.view = 'student_open_data'
+
+    extractor = AthenaDataExtractor(
+        configuration=cfg,
+        metadata=metadata,
+        dataset_specification=dataset
+    )
+
+    total = extractor.get_row_count()
+    assert total == 28_733_910
+
+
 def test_athena_count_with_space():
     if not AWS_PROFILE or not AWS_ATHENA_RESULTS_DIR or not AWS_REGION:
         pytest.skip("Skipping Athena test as AWS not configured")

--- a/test/test_data_extractor.py
+++ b/test/test_data_extractor.py
@@ -518,7 +518,7 @@ def test_partitioning_extractor_streaming():
 
 def test_hyper_total_measure():
     dataset = dataset_from_json(os.path.join('test', 'dataset.json'))
-    dataset.measures = []
+    dataset.measures = ['Sales']
     metadata = metadata_from_json(os.path.join('test', 'metadata.json'))
     configuration = Configuration(
         file_path=os.path.join('test', 'orders.hyper')
@@ -528,13 +528,19 @@ def test_hyper_total_measure():
         metadata=metadata,
         configuration=configuration
     )
-    assert extractor.get_total() == 10194
+
+    assert extractor.get_row_count() == 10194
     assert extractor.get_total(measure='Sales') == 2326534.354299952
+    # Defaults to "Sales" as measure is in dataset.measures()
+    assert extractor.get_total() == 2326534.354299952
+    # Raise ValueError if measure not in dataset.measures()
+    with pytest.raises(ValueError):
+        extractor.get_total(measure='Stuff')
 
 
 def test_hyper_to_csv():
     dataset = dataset_from_json(os.path.join('test', 'dataset.json'))
-    dataset.measures = []
+    dataset.measures = ['Sales']
     metadata = metadata_from_json(os.path.join('test', 'metadata.json'))
     configuration = Configuration(
         file_path=os.path.join('test', 'orders.hyper')
@@ -558,9 +564,10 @@ def test_hyper_to_csv():
     df = pd.read_csv(output_file)
     assert round(df['Sales'].sum(), 4) == 2326534.3543
 
+
 def test_hyper_to_csv_without_copy_to_tmp():
     dataset = dataset_from_json(os.path.join('test', 'dataset.json'))
-    dataset.measures = []
+    dataset.measures = ['Sales']
     metadata = metadata_from_json(os.path.join('test', 'metadata.json'))
     # Copy the source data to avoid overwriting during other pytest runs
     shutil.copyfile(
@@ -590,9 +597,10 @@ def test_hyper_to_csv_without_copy_to_tmp():
     df = pd.read_csv(output_file)
     assert round(df['Sales'].sum(), 4) == 2326534.3543
 
+
 def test_hyper_to_csv_without_using_pantab():
     dataset = dataset_from_json(os.path.join('test', 'dataset.json'))
-    dataset.measures = []
+    dataset.measures = ['Sales']
     metadata = metadata_from_json(os.path.join('test', 'metadata.json'))
     # Copy the source data to avoid overwriting during other pytest runs
     shutil.copyfile(

--- a/test/test_data_extractor.py
+++ b/test/test_data_extractor.py
@@ -808,6 +808,130 @@ def test_partitioning_extractor_with_row_numbers_apostrophes():
     assert 'row_number' not in columns
 
 
+def test_streaming_extractor_get_row_count():
+    # Skip if no DB configured
+    if not os.environ.get('CONNECTION_STRING'):
+        pytest.skip("Skipping SQL test as no database configured")
+
+    dataset = dataset_from_json(os.path.join('test', 'dataset.json'))
+    metadata = metadata_from_json(os.path.join('test', 'metadata.json'))
+
+    configuration = Configuration(
+        connection_string=os.environ.get('CONNECTION_STRING'),
+        schema="dev",
+        view="superstore",
+        query_builder=ViewBasedQueryBuilder
+    )
+
+    extractor = StreamingDataExtractor(
+        dataset_specification=dataset,
+        metadata=metadata,
+        configuration=configuration
+    )
+
+    # Trigger streaming so internal totals/row_count are computed
+    with tempfile.NamedTemporaryFile(suffix=".csv") as file:
+        extractor.stream_sql_to_csv(file_path=file.name, chunk_size=1000)
+
+    # Validate row count
+    assert extractor.get_row_count() == 10194
+
+
+def test_streaming_extractor_get_total():
+    # Skip if no DB configured
+    if not os.environ.get('CONNECTION_STRING'):
+        pytest.skip("Skipping SQL test as no database configured")
+
+    dataset = dataset_from_json(os.path.join('test', 'dataset.json'))
+    metadata = metadata_from_json(os.path.join('test', 'metadata.json'))
+
+    configuration = Configuration(
+        connection_string=os.environ.get('CONNECTION_STRING'),
+        schema="dev",
+        view="superstore",
+        query_builder=ViewBasedQueryBuilder
+    )
+
+    extractor = StreamingDataExtractor(
+        dataset_specification=dataset,
+        metadata=metadata,
+        configuration=configuration
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".csv") as file:
+        extractor.stream_sql_to_csv(file_path=file.name, chunk_size=1000)
+
+    # Default measure (dataset.measures[0])
+    total_default = extractor.get_total()
+
+    # Explicit measure
+    total_sales = extractor.get_total(measure="Sales")
+
+    assert round(total_default, 6) == round(2326534.3543, 6)
+    assert round(total_sales, 6) == round(2326534.3543, 6)
+
+
+def test_streaming_extractor_get_total_multiple_measures():
+    if not os.environ.get('CONNECTION_STRING'):
+        pytest.skip("Skipping SQL test as no database configured")
+
+    dataset = dataset_from_json(os.path.join('test', 'dataset.json'))
+    dataset.measures = ['Sales', 'Profit']
+
+    metadata = metadata_from_json(os.path.join('test', 'metadata.json'))
+
+    configuration = Configuration(
+        connection_string=os.environ.get('CONNECTION_STRING'),
+        schema="dev",
+        view="superstore",
+        query_builder=ViewBasedQueryBuilder
+    )
+
+    extractor = StreamingDataExtractor(
+        dataset_specification=dataset,
+        metadata=metadata,
+        configuration=configuration
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".csv") as file:
+        extractor.stream_sql_to_csv(file_path=file.name, chunk_size=1000)
+
+    assert round(extractor.get_total(measure="Sales"), 4) == 2326534.3543
+    assert round(extractor.get_total(measure="Profit"), 4) == 292296.8146
+
+
+def test_streaming_extractor_get_total_no_measures():
+    if not os.environ.get('CONNECTION_STRING'):
+        pytest.skip("Skipping SQL test as no database configured")
+
+    dataset = dataset_from_json(os.path.join('test', 'dataset.json'))
+    dataset.measures = []  # no measures
+
+    metadata = metadata_from_json(os.path.join('test', 'metadata.json'))
+
+    configuration = Configuration(
+        connection_string=os.environ.get('CONNECTION_STRING'),
+        schema="dev",
+        view="superstore",
+        query_builder=ViewBasedQueryBuilder
+    )
+
+    extractor = StreamingDataExtractor(
+        dataset_specification=dataset,
+        metadata=metadata,
+        configuration=configuration
+    )
+
+    with tempfile.NamedTemporaryFile(suffix=".csv") as file:
+        extractor.stream_sql_to_csv(file_path=file.name, chunk_size=1000)
+
+    # Falls back to row count
+    assert extractor.get_total() == 10194
+
+    with pytest.raises(ValueError):
+        extractor.get_total(measure="Sales")
+
+
 def test_consistency_across_extractors(tmp_path):
     """
     Ensure get_row_count and get_total are consistent across:

--- a/test/test_data_extractor.py
+++ b/test/test_data_extractor.py
@@ -558,7 +558,8 @@ def test_hyper_to_csv():
         minimise=False,
         compress_using_gzip=False
     )
-    assert extractor.get_total() == 10194
+    assert extractor.get_row_count() == 10194
+    assert  round(extractor.get_total(), 2) == 2326534.35
     assert round(extractor.get_total(measure='Sales'), 2) == 2326534.35
 
     df = pd.read_csv(output_file)
@@ -591,7 +592,7 @@ def test_hyper_to_csv_without_copy_to_tmp():
         compress_using_gzip=False,
         do_not_modify_source=False
     )
-    assert extractor.get_total() == 10194
+    assert extractor.get_row_count() == 10194
     assert round(extractor.get_total(measure='Sales'), 2) == 2326534.35
 
     df = pd.read_csv(output_file)
@@ -625,11 +626,12 @@ def test_hyper_to_csv_without_using_pantab():
         do_not_modify_source=False,
         use_pantab=False
     )
-    assert extractor.get_total() == 10194
+    assert extractor.get_row_count() == 10194
     assert round(extractor.get_total(measure='Sales'), 2) == 2326534.35
 
     df = pd.read_csv(output_file)
     assert round(df['Sales'].sum(), 4) == 2326534.3543
+
 
 def test_partitioning_extractor_partition_sql_no_data_in_partition():
     # Skip this test if we don't have a connection string

--- a/test/test_data_extractor.py
+++ b/test/test_data_extractor.py
@@ -806,3 +806,68 @@ def test_partitioning_extractor_with_row_numbers_apostrophes():
     columns = pd.read_csv(csv_file).columns
     # Check row_number omitted in CSV output
     assert 'row_number' not in columns
+
+
+def test_consistency_across_extractors(tmp_path):
+    """
+    Ensure get_row_count and get_total are consistent across:
+    - DataExtractor (CSV)
+    - HyperFile (Hyper)
+    """
+
+    # --- Setup dataset / metadata ---
+    dataset = dataset_from_json(os.path.join('test', 'dataset.json'))
+    metadata = metadata_from_json(os.path.join('test', 'metadata.json'))
+
+    csv_path = os.path.join('test', 'orders.csv')
+
+    # --- 1. DataExtractor (baseline) ---
+    base_config = Configuration(file_path=csv_path)
+    base_extractor = DataExtractor(
+        dataset_specification=dataset,
+        metadata=metadata,
+        configuration=base_config
+    )
+
+    base_extractor.validate_data()
+
+    base_row_count = base_extractor.get_row_count()
+    base_total_default = base_extractor.get_total()
+
+    # choose explicit measures
+    measures = dataset.measures.copy()
+    measures.remove('Profit Ratio')  # This is a calculation!
+
+    base_totals = {
+        m: base_extractor.get_total(measure=m)
+        for m in measures
+    }
+
+    # --- 2. Convert to Hyper ---
+    hyper_path = tmp_path / "test.hyper"
+
+    base_extractor.save_data_as_hyper(file_path=str(hyper_path))
+
+    # --- 3. HyperFile ---
+    hyper_config = Configuration(file_path=str(hyper_path))
+
+    hyper_extractor = HyperFile(
+        dataset_specification=dataset,
+        metadata=metadata,
+        configuration=hyper_config
+    )
+
+    hyper_row_count = hyper_extractor.get_row_count()
+    hyper_total_default = hyper_extractor.get_total()
+
+    hyper_totals = {
+        m: hyper_extractor.get_total(measure=m)
+        for m in measures
+    }
+
+    # --- Assertions: STRICT consistency ---
+    assert hyper_row_count == base_row_count
+    assert round(hyper_total_default, 6) == round(base_total_default, 6)
+
+    for m in measures:
+        assert round(hyper_totals[m], 6) == round(base_totals[m], 6)


### PR DESCRIPTION
## 📌 Summary

This change ensures that each Extractor subclass contains:

get_row_count()
get_total(measure:str)

Calling code should now call either:
- get_row_count() if you want a row count
- get_total(measure) if you want to sum by a specific measure
- calling get_total() is discouraged.

The behaviour is consistent across implementations:

- get_row_count() returns the row count
- get_total(measure) returns SUM of measure if measure is not None and that measure exists in dataset.measures
- get_total(measure) raises ValueError when measure is not None and the measure does not exist in dataset.measures
- get_total(measure) returns SUM of the first measure in dataset.measures if measure is None and there are measures in dataset.measures
- get_total(measure) returns the row count if measure is None and there are no measures in dataset.measures

Notes: 

1. this is slightly different from the previous behaviour, where if a measure was specified that did not exist, the row_count was returned.
2. 'Find a default measure' logic was previously also in SubsetQueryBuilder. I've removed this - the only place default measures are substituted for None is now in the Extractor layer.

---

## 🧪 What Changed?

- [x] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation only
- [ ] CI/CD or tooling
- [ ] Other (please explain):

---

## ✅ Checklist

### Code Quality
- [x ] Code is clean, commented, and follows our conventions
- [x ] No hardcoded values or secrets
- [x ] Reusable and modular where possible

### Testing
- [x] I have tested this change locally
- [x] Relevant tests have been added/updated
- [x] All existing tests still pass

### Documentation
- [x] Code comments or inline explanations added where needed
- [ ] README / documentation updated (if applicable)
- [ ] Any environment variables added are documented

### Security & Deployment
- [x] No sensitive data in code or logs
- [x] No breaking changes introduced
- [ ] Deploy scripts / jobs updated (if needed)

Note that there is a change in behaviour for where a non-existent measure is specified for a total.
---

## ⚙️ Actions Required After Pulling

- [ ] Yes.
- [x] No.

> If you checked **Yes**, please provide instructions below:

---

## 🧠 Context or Screenshots

---

## 🚨 Risk & Impact

- [ ] No user-facing changes
- [ ] Minimal risk — small changes isolated to specific areas
- [x] Medium risk — changes affect multiple areas
- [ ] High risk — could impact critical paths or user flows

> Notes for reviewers (optional):

